### PR TITLE
EVA-2132 - genome downloader

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python setup.py install
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -36,4 +37,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest tests
+        PYTHONPATH=. pytest tests

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 EBI EVA - Common Python Utilities
+
+
+# Assembly retrieval module
+Create a object that will download and organise all the assemblies under onw directory.
+The scientific name is provided to place the assembly in a species specific subfolder. 
+No checks are performed to see if the assembly and the species match.
+
+```python
+from ebi_eva_common_pyutils.assembly import NCBIAssembly
+
+assembly = NCBIAssembly('GCA_000008865.1', 'Escherichia coli O157:H7 str. Sakai', download_destination)
+assembly.download_or_construct()
+assembly.assembly_fasta_path
+```
+
+To only download the report
+```python
+from ebi_eva_common_pyutils.assembly import NCBIAssembly
+
+assembly = NCBIAssembly('GCA_000008865.1', 'Escherichia coli O157:H7 str. Sakai', download_destination)
+assembly.download_assembly_report()
+assembly.assembly_report_path
+```
+
+
+# Logging
+
+Central logging is provided by the logger module which takes care of propagating all handler to any newly created logger.
+You need to create at least one handler for the logging to happen.
+
+```python
+from ebi_eva_common_pyutils.logger import logging_config as log_cfg 
+log_cfg.add_stderr_handler()
+logger = log_cfg.get_logger(__name__)
+logger.info('Information')
+```
+
+Or from any class
+```python
+from ebi_eva_common_pyutils.logger import logging_config as log_cfg 
+
+class Foo(log_cfg.AppLogger):
+
+    def bar(self):
+        self.info('Information')
+
+def main():
+    log_cfg.add_stderr_handler()
+```
+ 

--- a/ebi_eva_common_pyutils/assembly/__init__.py
+++ b/ebi_eva_common_pyutils/assembly/__init__.py
@@ -1,0 +1,1 @@
+from ebi_eva_common_pyutils.assembly.assembly import NCBIAssembly

--- a/ebi_eva_common_pyutils/assembly/assembly.py
+++ b/ebi_eva_common_pyutils/assembly/assembly.py
@@ -155,7 +155,7 @@ class NCBIAssembly(AppLogger):
                 'gunzip -f {}'.format(self.assembly_compressed_fasta_path)
             )
 
-    def construct_fasta_from_report(self, genebank_only=False):
+    def construct_fasta_from_report(self, genbank_only=False):
         """
         Download the assembly report if it does not exist then create the assembly fasta from the contig.
         If the assembly already exist then it only add any missing contig.
@@ -219,7 +219,7 @@ class NCBIAssembly(AppLogger):
         self.info('Downloading ' + contig_accession)
         urllib.request.urlretrieve(url, output_file)
 
-    def download_or_construct(self, genebank_only=False, overwrite=False):
+    def download_or_construct(self, genbank_only=False, overwrite=False):
         """First download the assembly report and fasta from the FTP, then append any missing contig from
         the assembly report to the assembly fasta."""
         self.download_assembly_report(overwrite)

--- a/ebi_eva_common_pyutils/assembly/assembly.py
+++ b/ebi_eva_common_pyutils/assembly/assembly.py
@@ -167,7 +167,7 @@ class NCBIAssembly(AppLogger):
             refseq_accession = row['RefSeq-Accn']
             relationship = row['Relationship']
             accession = genbank_accession
-            if relationship != '=' and genbank_accession == 'na' and not genebank_only:
+            if relationship != '=' and genbank_accession == 'na' and not genbank_only:
                 accession = refseq_accession
             if accession in written_contigs:
                 self.info('Accession ' + accession + ' already in the FASTA file, don\'t need to be downloaded')
@@ -228,4 +228,4 @@ class NCBIAssembly(AppLogger):
         except:
             pass
         # This will either confirm the presence of all the contig or download any one missing
-        self.construct_fasta_from_report(genebank_only)
+        self.construct_fasta_from_report(genbank_only)

--- a/ebi_eva_common_pyutils/assembly/assembly.py
+++ b/ebi_eva_common_pyutils/assembly/assembly.py
@@ -1,0 +1,228 @@
+# Copyright 2019 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import urllib
+from csv import DictReader, excel_tab
+from ftplib import FTP
+import re
+from urllib import request
+
+from cached_property import cached_property
+from retry import retry
+
+from ebi_eva_common_pyutils.command_utils import run_command_with_output
+from ebi_eva_common_pyutils.logger import AppLogger
+
+
+class NCBIAssembly(AppLogger):
+    """
+    Class that represent an assembly that would originate from NCBI data
+    It takes a GCA or GCF accession and can download the assembly report and genomics fasta.
+    Using species_scientific_name and assembly_accession it create a directory structure in the provided
+    reference_directory:
+        - species_scientific_name1
+            - assembly_accession1
+            - assembly_accession2
+        - species_scientific_name2
+    the eutils_api_key is only used to retrieve additional contigs if required.
+    """
+
+    def __init__(self, assembly_accession, species_scientific_name, reference_directory, eutils_api_key=None):
+        self.check_assembly_accession_format(assembly_accession)
+        self.assembly_accession = assembly_accession
+        self.species_scientific_name = species_scientific_name
+        self.reference_directory = reference_directory
+        self.eutils_api_key = eutils_api_key
+
+    @staticmethod
+    def check_assembly_accession_format(assembly_accession):
+        if re.match(r"^GC[F|A]_\d+\.\d+$", assembly_accession) is None:
+            raise Exception('Invalid assembly accession: it has to be in the form of '
+                            'GCF_XXXXXXXXX.X or GCA_XXXXXXXXX.X where X is a number')
+
+    @property
+    def assembly_directory(self):
+        assembly_directory = os.path.join(
+            self.reference_directory,  self.species_scientific_name.lower().replace(' ', '_'), self.assembly_accession
+        )
+        os.makedirs(assembly_directory, exist_ok=True),
+        return assembly_directory
+
+    @property
+    def assembly_report_path(self):
+        return os.path.join( self.assembly_directory, self.assembly_accession + '_assembly_report.txt')
+
+    @property
+    def assembly_fasta_path(self):
+        return os.path.join(self.assembly_directory, self.assembly_accession + '.fa')
+
+    @property
+    def assembly_compressed_fasta_path(self):
+        return os.path.join(self.assembly_directory, self.assembly_accession + '.fa.gz')
+
+    @retry(tries=4, delay=2, backoff=1.2, jitter=(1, 3))
+    def _download_file(self, destination_file, url):
+        self.info('Download assembly file for %s to %s', self.assembly_accession, destination_file)
+        request.urlretrieve(url, destination_file)
+        request.urlcleanup()
+
+    @cached_property
+    def _ncbi_genome_folder_url_and_content(self):
+        """
+        Internal property that retrieve and store the NCBI ftp url and content of the genome folder.
+        """
+        ftp = FTP('ftp.ncbi.nlm.nih.gov', timeout=600)
+        genome_folder = 'genomes/all/' + '/'.join([self.assembly_accession[0:3], self.assembly_accession[4:7],
+                                                   self.assembly_accession[7:10],
+                                                   self.assembly_accession[10:13]]) + '/'
+        ftp.cwd(genome_folder)
+        all_genome_subfolders = []
+        ftp.retrlines('NLST', lambda line: all_genome_subfolders.append(line))
+
+        genome_subfolders = [folder for folder in all_genome_subfolders if self.assembly_accession in folder]
+        if len(genome_subfolders) != 1:
+            raise Exception('more than one folder matches the assembly accession: ' + str(genome_subfolders))
+        ftp.cwd(genome_subfolders[0])
+        genome_files = []
+        ftp.retrlines('NLST', lambda line: genome_files.append(line))
+        url = 'ftp://' + 'ftp.ncbi.nlm.nih.gov' + '/' + genome_folder + genome_subfolders[0]
+        ftp.close()
+        return url, genome_files
+
+    @cached_property
+    def assembly_report_url(self):
+        """
+        Search on the NCBI FTP for the assembly report file and return the full url if only one found.
+        Raise if not.
+        """
+        url, genome_files = self._ncbi_genome_folder_url_and_content
+        assembly_reports = [genome_file for genome_file in genome_files if 'assembly_report.txt' in genome_file]
+        if len(assembly_reports) != 1:
+            raise Exception('more than one file has "assembly_report" in its name: ' + str(assembly_reports))
+        return url + '/' + assembly_reports[0]
+
+    @cached_property
+    def assembly_fasta_url(self):
+        """
+        Search on the NCBI FTP for the assembly genomics fasta file and return the full url if only one found.
+        Raise if not.
+        """
+        url, genome_files = self._ncbi_genome_folder_url_and_content
+        assembly_fasta = [genome_file for genome_file in genome_files if genome_file.endswith('_genomic.fna.gz')]
+        # Remove the entries that are from genomics dna but the whole genome
+        assembly_fasta = [fasta for fasta in assembly_fasta if '_from_' not in fasta ]
+        if len(assembly_fasta) > 1:
+            raise Exception('{} file found ending with "_genomic.fna.gz" in its name: {}'.format(len(assembly_fasta),
+                                                                                                 assembly_fasta))
+        return url + '/' + assembly_fasta[0]
+
+    def get_assembly_report_rows(self):
+        """Download the assembly report if it does not exist then parse it to create a generator
+        that return each row as a dict."""
+        self.download_assembly_report()
+        with open(self.assembly_report_path) as open_file:
+            headers = None
+            # Parse the assembly report file to find the header then stop
+            for line in open_file:
+                if line.lower().startswith("# sequence-name") and "sequence-role" in line.lower():
+                    headers = line.strip().split('\t')
+                    break
+            reader = DictReader(open_file, fieldnames=headers, dialect=excel_tab)
+            for record in reader:
+                yield record
+
+    def download_assembly_report(self, overwrite=False):
+        if not os.path.isfile(self.assembly_report_path) or overwrite:
+            self._download_file(self.assembly_report_path, self.assembly_report_url)
+
+    def download_assembly_fasta(self, overwrite=False):
+        if not os.path.isfile(self.assembly_fasta_path) or overwrite:
+            self._download_file(self.assembly_compressed_fasta_path, self.assembly_fasta_url)
+            run_command_with_output(
+                'Uncompress {}'.format(self.assembly_compressed_fasta_path),
+                'gunzip -f {}'.format(self.assembly_compressed_fasta_path)
+            )
+
+    def construct_fasta_from_report(self):
+        """
+        Download the assembly report if it does not exist then create the assembly fasta from the contig.
+        If the assembly already exist then it only add any missing contig.
+        """
+        written_contigs = self.get_written_contigs(self.assembly_fasta_path)
+        contig_to_append = []
+        for row in self.get_assembly_report_rows():
+            genbank_accession = row['GenBank-Accn']
+            refseq_accession = row['RefSeq-Accn']
+            relationship = row['Relationship']
+            accession = genbank_accession
+            if relationship != '=' and genbank_accession == 'na':
+                accession = refseq_accession
+            if genbank_accession in written_contigs or refseq_accession in written_contigs:
+                self.info('Accession ' + accession + ' already in the FASTA file, don\'t need to be downloaded')
+                continue
+            contig_to_append.append(self.download_contig_sequence_from_ncbi(accession))
+
+        # Now append all the new contigs to the existing fasta
+        with open(self.assembly_fasta_path, 'a+') as fasta:
+            for contig_path in contig_to_append:
+                with open(contig_path) as sequence:
+                    for line in sequence:
+                        # Check that the line is not empty
+                        if line.strip():
+                            fasta.write(line)
+                os.remove(contig_path)
+
+    def download_contig_sequence_from_ncbi(self, accession):
+        sequence_tmp_path = os.path.join(self.assembly_directory, accession + '.fa')
+        self.download_contig_from_ncbi(accession, sequence_tmp_path)
+        self.info(accession + " downloaded and added to FASTA sequence")
+        return sequence_tmp_path
+
+    @staticmethod
+    def get_written_contigs(fasta_path):
+        written_contigs = []
+        match = re.compile(r'>(.*?)\s')
+        if os.path.isfile(fasta_path):
+            with open(fasta_path, 'r') as file:
+                for line in file:
+                    written_contigs.extend(match.findall(line))
+        return written_contigs
+
+    @retry(tries=4, delay=2, backoff=1.2, jitter=(1, 3))
+    def download_contig_from_ncbi(self, contig_accession, output_file):
+        parameters = {
+            'db':'nuccore',
+            'id':contig_accession,
+            'rettype': 'fasta',
+            'retmode': 'text',
+            'tool': 'eva',
+            'email': 'eva-dev@ebi.ac.uk'
+        }
+        if self.eutils_api_key:
+            parameters['api_key'] = self.eutils_api_key
+
+        url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?' + urllib.parse.urlencode(parameters)
+        self.info('Downloading ' + contig_accession)
+        urllib.request.urlretrieve(url, output_file)
+
+    def download_or_construct(self, overwrite=False):
+        """First download the assembly report and fasta from the FTP, then append any missing contig from
+        the assembly report to the assembly fasta."""
+        try:
+            self.download_assembly_fasta(overwrite)
+            self.download_assembly_report(overwrite)
+        except:
+            pass
+        # This will either confirm the presence of all the contig or download any one missing
+        self.construct_fasta_from_report()

--- a/ebi_eva_common_pyutils/assembly/assembly.py
+++ b/ebi_eva_common_pyutils/assembly/assembly.py
@@ -83,6 +83,7 @@ class NCBIAssembly(AppLogger):
         Internal property that retrieve and store the NCBI ftp url and content of the genome folder.
         """
         ftp = FTP('ftp.ncbi.nlm.nih.gov', timeout=600)
+        ftp.login('anonymous', 'anonymous')
         genome_folder = 'genomes/all/' + '/'.join([self.assembly_accession[0:3], self.assembly_accession[4:7],
                                                    self.assembly_accession[7:10],
                                                    self.assembly_accession[10:13]]) + '/'

--- a/ebi_eva_common_pyutils/config_utils.py
+++ b/ebi_eva_common_pyutils/config_utils.py
@@ -17,6 +17,7 @@ from lxml import etree as et
 import json
 import yaml
 import urllib.request
+from retry import retry
 
 
 class EVAPrivateSettingsXMLConfig:
@@ -76,6 +77,7 @@ def get_profile_properties(profile, root):
     return properties
 
 
+@retry(tries=4, delay=2, backoff=1.2, jitter=(1, 3))
 def get_eva_settings_xml_string(token):
     url = 'https://api.github.com/repos/EBIvariation/configuration/contents/eva-maven-settings.xml'
     headers = {'Authorization': 'token ' + token, 'Accept' : 'application/vnd.github.raw' }

--- a/ebi_eva_common_pyutils/config_utils.py
+++ b/ebi_eva_common_pyutils/config_utils.py
@@ -14,6 +14,9 @@
 
 from urllib.parse import quote_plus
 from lxml import etree as et
+import json
+import yaml
+import urllib.request
 
 
 class EVAPrivateSettingsXMLConfig:
@@ -53,3 +56,40 @@ def get_mongo_uri_for_eva_profile(eva_profile_name: str, settings_xml_file: str)
     authentication_db = config.get_value_with_xpath(
         xpath_location_template.format(eva_profile_name, "eva.mongo.auth.db"))[0]
     return "mongodb://{0}:{1}@{2}/{3}".format(username, quote_plus(password), mongo_hosts_and_ports, authentication_db)
+
+
+def get_properties_from_xml_file(profile, xml_path):
+    tree = et.parse(xml_path)
+    root = tree.getroot()
+    return get_profile_properties(profile, root)
+
+
+def get_properties_from_xml_string(profile, str):
+    root = et.fromstring(str)
+    return get_profile_properties(profile, root)
+
+
+def get_profile_properties(profile, root):
+    properties = {}
+    for property in root.xpath('//settings/profiles/profile/id[text()="' + profile + '"]/../properties/*'):
+        properties[property.tag] = property.text
+    return properties
+
+
+def get_eva_settings_xml_string(token):
+    url = 'https://api.github.com/repos/EBIvariation/configuration/contents/eva-maven-settings.xml'
+    headers = {'Authorization': 'token ' + token, 'Accept' : 'application/vnd.github.raw' }
+    request = urllib.request.Request(url, None, headers)
+    with urllib.request.urlopen(request) as response:
+        return response.read()
+
+
+def get_args_from_private_config_file(private_config_file):
+    with open(private_config_file) as private_config_file_handle:
+        if 'json' in private_config_file:
+            return json.load(private_config_file_handle)
+        else:
+            if 'yml' in private_config_file:
+                return yaml.safe_load(private_config_file_handle)
+            else:
+                raise TypeError('Configuration file should be either json or yaml')

--- a/ebi_eva_common_pyutils/logger.py
+++ b/ebi_eva_common_pyutils/logger.py
@@ -1,0 +1,144 @@
+# Copyright 2020 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import logging.config
+import logging.handlers
+from sys import stdout, stderr
+from cached_property import cached_property
+
+
+class LoggingConfiguration:
+    """
+    This class provides an all in one management of all loggers in the stack. By default it pulls existing loggers,
+    stores additional ones along with handlers and formatters.
+    """
+
+    default_fmt = '[%(asctime)s][%(name)s][%(levelname)s] %(message)s'
+    default_datefmt = '%Y-%b-%d %H:%M:%S'
+
+    def __init__(self, use_existing_logger=True, log_level=logging.INFO):
+        self.blank_formatter = logging.Formatter()
+        self.handlers = set()
+        if use_existing_logger:
+            # retrieve all third party loggers
+            self.loggers = dict((name, logger)
+                                for name, logger in logging.root.manager.loggerDict.items()
+                                if isinstance(logger, logging.Logger))
+        else:
+            self.loggers = {}
+        self._log_level = log_level
+
+    @cached_property
+    def formatter(self):
+        return self.default_formatter
+
+    @cached_property
+    def default_formatter(self):
+        return logging.Formatter(
+            fmt=self.default_fmt,
+            datefmt=self.default_datefmt
+        )
+
+    def get_logger(self, name, level=logging.NOTSET):
+        """
+        Return a logging.Logger object with formatters and handlers added.
+        :param name: Name to assign to the logger (usually __name__)
+        :param int level: Log level to assign to the logger upon creation
+        """
+        if name in self.loggers:
+            logger = self.loggers[name]
+        else:
+            logger = logging.getLogger(name)
+            self.loggers[name] = logger
+
+        logger.setLevel(level or self._log_level)
+        for h in self.handlers:
+            logger.addHandler(h)
+
+        return logger
+
+    def add_handler(self, handler, level=logging.NOTSET):
+        """
+        Add a created handler, set its format/level if needed and register all loggers to it
+        :param logging.Handler handler:
+        :param int level: Log level to assign to the created handler
+        """
+        handler.setLevel(level or self._log_level)
+        handler.setFormatter(self.formatter)
+        for name in self.loggers:
+            self.loggers[name].addHandler(handler)
+        self.handlers.add(handler)
+
+    def add_stdout_handler(self, level=None):
+        self.add_handler(logging.StreamHandler(stdout), level=level or self._log_level)
+
+    def add_stderr_handler(self, level=None):
+        self.add_handler(logging.StreamHandler(stderr), level=level or self._log_level)
+
+    def set_log_level(self, level):
+        self._log_level = level
+        for h in self.handlers:
+            h.setLevel(self._log_level)
+        for name in self.loggers:
+            self.loggers[name].setLevel(self._log_level)
+
+    def set_formatter(self, formatter):
+        """
+        Set all handlers to use formatter
+        :param logging.Formatter formatter:
+        """
+        self.__dict__['formatter'] = formatter
+        for h in self.handlers:
+            h.setFormatter(self.formatter)
+
+    def reset(self):
+        """Remove all handlers of existing logger"""
+        for l in self.loggers.values():
+            while l.handlers:
+                l.removeHandler(l.handlers[0])
+
+        while self.handlers:
+            h = self.handlers.pop()
+            del h
+
+
+# A logging configuration singleton that will be the only source of logger
+logging_config = LoggingConfiguration()
+
+
+class AppLogger:
+    """
+    Mixin class for logging. An object subclassing this can log using its class name. Contains a
+    logging.Logger object and exposes its log methods.
+    """
+    log_cfg = logging_config
+
+    def debug(self, msg, *args):
+        self._logger.debug(msg, *args)
+
+    def info(self, msg, *args):
+        self._logger.info(msg, *args)
+
+    def warning(self, msg, *args):
+        self._logger.warning(msg, *args)
+
+    def error(self, msg, *args):
+        self._logger.error(msg, *args)
+
+    def critical(self, msg, *args):
+        self._logger.critical(msg, *args)
+
+    @cached_property
+    def _logger(self):
+        return self.log_cfg.get_logger(self.__class__.__name__)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages
 setup(
     name='ebi_eva_common_pyutils',
     packages=find_packages(),
-    version='0.3.4',
+    version='0.3.5',
     license='Apache',
     description='EBI EVA - Common Python Utilities',
     url='https://github.com/EBIVariation/eva-common-pyutils',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages
 setup(
     name='ebi_eva_common_pyutils',
     packages=find_packages(),
-    version='0.3.2',
+    version='0.3.4',
     license='Apache',
     description='EBI EVA - Common Python Utilities',
     url='https://github.com/EBIVariation/eva-common-pyutils',

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ from setuptools import find_packages
 setup(
     name='ebi_eva_common_pyutils',
     packages=find_packages(),
-    version='0.2.8',
+    version='0.3.2',
     license='Apache',
     description='EBI EVA - Common Python Utilities',
     url='https://github.com/EBIVariation/eva-common-pyutils',
     keywords=['EBI', 'EVA', 'PYTHON', 'UTILITIES'],
-    install_requires=['psycopg2-binary', 'requests', 'pymongo', 'lxml'],
+    install_requires=['psycopg2-binary', 'requests', 'pymongo', 'lxml', 'pyyaml', 'cached-property', 'retry'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/tests/resources/test_config_file.xml
+++ b/tests/resources/test_config_file.xml
@@ -1,0 +1,23 @@
+<settings>
+    <profiles>
+        <profile>
+            <id>test</id>
+            <properties>
+                <eva.mongo.host>mongo.example.com:27017</eva.mongo.host>
+                <eva.mongo.user>testuser</eva.mongo.user>
+                <eva.mongo.passwd>testpassword</eva.mongo.passwd>
+                <eva.mongo.passwd.url-encoded>testpassword</eva.mongo.passwd.url-encoded>
+                <eva.mongo.auth.db>admin</eva.mongo.auth.db>
+                <eva.mongo.read-preference>secondaryPreferred</eva.mongo.read-preference>
+                <eva.evapro.jdbc.url>jdbc:postgresql://pgsql.example.com:5432/testdatabase</eva.evapro.jdbc.url>
+            </properties>
+        </profile>
+    </profiles>
+    <servers>
+        <server>
+            <id>eva-test</id>
+            <username>testuser</username>
+            <password>testpassword</password>
+        </server>
+   </servers>
+</settings>

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -93,7 +93,7 @@ class TestNCBIAssembly(TestCommon):
         self.assertRaises(
             ValueError,
             self.assembly_from_report.construct_fasta_from_report,
-            genebank_only=True
+            genbank_only=True
         )
 
     def test_download_or_construct(self):

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1,0 +1,102 @@
+import os
+import shutil
+from unittest.mock import Mock
+
+from ebi_eva_common_pyutils.assembly.assembly import NCBIAssembly
+from tests.test_common import TestCommon
+
+
+class TestNCBIAssembly(TestCommon):
+
+    assembly_report = os.path.join(os.path.dirname(os.path.dirname(__file__)), "GCA_000000000.0_assembly_report.txt")
+    assembly_report_header = (
+        '# Sequence-Name', 'Sequence-Role', 'Assigned-Molecule', 'Assigned-Molecule-Location/Type','GenBank-Accn',
+        'Relationship', 'RefSeq-Accn', 'Assembly-Unit', 'Sequence-Length', 'UCSC-style-name'
+    )
+    assembly_report_line1 = (
+        'scaffold_3134', 'unplaced-scaffold', 'na', 'na', 'LODP01002389.1', '=', 'NW_017892567.1', 'Primary Assembly',
+        '3525', 'na'
+    )
+
+    def setUp(self) -> None:
+        self.genome_folder = os.path.join(self.resources_folder, 'genomes')
+        os.makedirs(self.genome_folder, exist_ok=True)
+        self.assembly = NCBIAssembly('GCA_000008865.1', 'Escherichia coli O157:H7 str. Sakai', self.genome_folder)
+
+        # Fake assembly that will be downloaded from pre-made report
+        self.assembly_from_report = NCBIAssembly('GCA_000000000.0', 'Thingy thung', self.genome_folder)
+        assembly_dir = os.path.join(self.genome_folder, 'thingy_thung', 'GCA_000000000.0')
+        os.makedirs(assembly_dir, exist_ok=True)
+        with open(os.path.join(assembly_dir, 'GCA_000000000.0_assembly_report.txt'), 'w') as open_file:
+            lines = ['\t'.join(l) for l in [self.assembly_report_header, self.assembly_report_line1]]
+            open_file.write('\n'.join(lines))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(os.path.join(self.genome_folder))
+
+    def test_get_assembly_report_rows(self):
+        expected_lines = [
+            {'# Sequence-Name': 'ANONYMOUS', 'Sequence-Role': 'assembled-molecule', 'Assigned-Molecule': 'na',
+             'Assigned-Molecule-Location/Type': 'Chromosome', 'GenBank-Accn': 'BA000007.2', 'Relationship': '=',
+             'RefSeq-Accn': 'NC_002695.1', 'Assembly-Unit': 'Primary Assembly', 'Sequence-Length': '5498450',
+             'UCSC-style-name': 'na'},
+            {'# Sequence-Name': 'pO157', 'Sequence-Role': 'assembled-molecule', 'Assigned-Molecule': 'pO157',
+             'Assigned-Molecule-Location/Type': 'Plasmid', 'GenBank-Accn': 'AB011549.2', 'Relationship': '=',
+             'RefSeq-Accn': 'NC_002128.1', 'Assembly-Unit': 'Primary Assembly', 'Sequence-Length': '92721',
+             'UCSC-style-name': 'na'},
+            {'# Sequence-Name': 'pOSAK1', 'Sequence-Role': 'assembled-molecule', 'Assigned-Molecule': 'pOSAK1',
+             'Assigned-Molecule-Location/Type': 'Plasmid', 'GenBank-Accn': 'AB011548.2', 'Relationship': '=',
+             'RefSeq-Accn': 'NC_002127.1', 'Assembly-Unit': 'Primary Assembly', 'Sequence-Length': '3306',
+             'UCSC-style-name': 'na'},
+        ]
+        for i, line_dict in enumerate(self.assembly.get_assembly_report_rows()):
+            self.assertEqual(line_dict, expected_lines[i])
+
+    def test_download_assembly_report(self):
+        self.assertFalse(os.path.isfile(self.assembly.assembly_report_path))
+        self.assembly.download_assembly_report()
+        self.assertTrue(os.path.isfile(self.assembly.assembly_report_path))
+
+    def test_download_assembly_fasta(self):
+        self.assertFalse(os.path.isfile(self.assembly.assembly_fasta_path))
+        self.assembly.download_assembly_fasta()
+        self.assertTrue(os.path.isfile(self.assembly.assembly_fasta_path))
+
+    def test_construct_fasta_from_report(self):
+        self.assertTrue(os.path.isfile(self.assembly_from_report.assembly_report_path))
+        self.assembly_from_report.construct_fasta_from_report()
+        self.assertTrue(os.path.isfile(self.assembly_from_report.assembly_fasta_path))
+        self.assertEqual(
+            NCBIAssembly.get_written_contigs(self.assembly_from_report.assembly_fasta_path),
+            ['LODP01002389.1']
+        )
+
+    def test_download_or_construct(self):
+        self.assertFalse(os.path.isfile(self.assembly.assembly_report_path))
+        self.assertFalse(os.path.isfile(self.assembly.assembly_fasta_path))
+        # Get the assembly from the FTP
+        self.assembly.download_or_construct()
+        self.assertTrue(os.path.isfile(self.assembly.assembly_report_path))
+        self.assertTrue(os.path.isfile(self.assembly.assembly_fasta_path))
+
+        self.assertEqual(
+            NCBIAssembly.get_written_contigs(self.assembly.assembly_fasta_path),
+            ['BA000007.2', 'AB011549.2', 'AB011548.2']
+        )
+
+        # Append to the assembly report and download the
+        with open(self.assembly.assembly_report_path, 'a') as open_file:
+            open_file.write('\t'.join(self.assembly_report_line1) + '\n')
+
+        # Disable the object capability to access the FTP and delete the cached URL to show that only the new
+        # contig is downloaded.
+        self.assembly._ncbi_genome_folder_url_and_content = Mock()
+        self.assembly.__dict__['assembly_report_url']
+        self.assembly.__dict__['assembly_fasta_url']
+
+        self.assembly.download_or_construct()
+        self.assertEqual(
+            NCBIAssembly.get_written_contigs(self.assembly.assembly_fasta_path),
+            ['BA000007.2', 'AB011549.2', 'AB011548.2', 'LODP01002389.1']
+        )
+

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,8 @@
+import os
+from unittest import TestCase
+
+
+class TestCommon(TestCase):
+
+    resources_folder = os.path.join(os.path.dirname(__file__), 'resources')
+

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,0 +1,66 @@
+# Copyright 2020 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from lxml.etree import XPathEvalError
+
+from ebi_eva_common_pyutils.config_utils import EVAPrivateSettingsXMLConfig, get_pg_metadata_uri_for_eva_profile, \
+    get_mongo_uri_for_eva_profile
+from tests.test_common import TestCommon
+
+
+class TestEVAPrivateSettingsXMLConfig(TestCommon):
+
+    def setUp(self) -> None:
+        self.config_file = os.path.join(self.resources_folder, 'test_config_file.xml')
+        self.private_settings = EVAPrivateSettingsXMLConfig(self.config_file)
+
+    def test_get_value_with_xpath(self):
+        self.assertEqual(
+            self.private_settings.get_value_with_xpath(
+                '//settings/profiles/profile/id[text()="test"]/../properties/eva.mongo.host/text()'
+            ),
+            ['mongo.example.com:27017']
+        )
+        self.assertRaises(
+            ValueError,
+            self.private_settings.get_value_with_xpath,
+            '//settings/profiles/profile/id[text()="failedtest"]/../properties/eva.mongo.host/text()'
+        )
+        self.assertRaises(
+            XPathEvalError,
+            self.private_settings.get_value_with_xpath,
+            '//anystring/{}'
+        )
+
+
+class TestDatabaseConfig(TestCommon):
+
+    def setUp(self) -> None:
+        self.config_file = os.path.join(os.path.dirname(__file__), 'resources', 'test_config_file.xml')
+
+    def test_get_pg_metadata_uri_for_eva_profile(self):
+        self.assertEqual(
+            get_pg_metadata_uri_for_eva_profile('test', self.config_file),
+            'postgresql://pgsql.example.com:5432/testdatabase'
+        )
+
+    def test_get_mongo_uri_for_eva_profile(self):
+        self.assertEqual(
+            get_mongo_uri_for_eva_profile('test', self.config_file),
+            'mongodb://testuser:testpassword@mongo.example.com:27017/admin'
+        )
+        self.assertRaises(
+            ValueError,
+            get_mongo_uri_for_eva_profile, 'test1', self.config_file
+        )

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,89 @@
+import sys
+import logging
+import logging.handlers
+from unittest.mock import Mock
+
+from ebi_eva_common_pyutils.logger import AppLogger, LoggingConfiguration
+from tests.test_common import TestCommon
+
+
+class TestLoggingConfiguration(TestCommon):
+
+    def setUp(self) -> None:
+        self.log_cfg = LoggingConfiguration()
+        self.log_cfg.reset()
+
+    def test_formatters(self):
+        default = self.log_cfg.default_formatter
+        assert default.datefmt == '%Y-%b-%d %H:%M:%S'
+        assert default._fmt == '[%(asctime)s][%(name)s][%(levelname)s] %(message)s'
+
+        blank = self.log_cfg.blank_formatter
+        assert blank.datefmt is None
+        assert blank._fmt == '%(message)s'
+
+        assert self.log_cfg.formatter is default
+
+        assert self.log_cfg.handlers == set()
+        assert self.log_cfg._log_level == logging.INFO
+
+    def test_get_logger(self):
+        l = self.log_cfg.get_logger('a_logger')
+        assert l.level == self.log_cfg._log_level
+        assert l in self.log_cfg.loggers.values()
+        assert list(self.log_cfg.handlers) == l.handlers
+
+    def test_add_handler(self):
+        h = logging.StreamHandler(stream=sys.stdout)
+        self.log_cfg.add_handler(h)
+
+        assert h in self.log_cfg.handlers
+        assert h.formatter is self.log_cfg.formatter
+        assert h.level == logging.INFO
+
+    def test_set_log_level(self):
+        h = logging.StreamHandler(stream=sys.stdout)
+        self.log_cfg.add_handler(h, level=logging.INFO)
+        l = self.log_cfg.get_logger('a_logger')
+        assert h.level == l.level == logging.INFO
+
+        self.log_cfg.set_log_level(logging.DEBUG)
+        assert h.level == l.level == logging.DEBUG
+
+    def test_set_formatter(self):
+        h = logging.StreamHandler(stream=sys.stdout)
+        self.log_cfg.add_handler(h)
+
+        self.log_cfg.set_formatter(self.log_cfg.blank_formatter)
+        assert h.formatter is self.log_cfg.blank_formatter
+        self.log_cfg.set_formatter(self.log_cfg.default_formatter)
+        assert h.formatter is self.log_cfg.default_formatter
+
+    def test_reset(self):
+        l = self.log_cfg.get_logger('a_logger')
+        assert not l.handlers  # not set up yet
+
+        self.log_cfg.add_stdout_handler()
+        assert len(self.log_cfg.handlers) == 1
+        assert len(l.handlers) == 1
+        self.log_cfg.reset()
+
+        assert not self.log_cfg.handlers
+        assert not l.handlers  # logger still exists, has no handlers
+
+
+class TestAppLogger(TestCommon):
+    def setUp(self):
+        self.log_cfg = LoggingConfiguration()
+        self.app_logger = AppLogger()
+        self.app_logger.log_cfg = self.log_cfg
+
+    def tearDown(self):
+        self.app_logger = None
+        self.log_cfg = None
+
+    def test_info(self):
+        self.log_cfg.get_logger = Mock()
+        self.app_logger.info('Things')
+        self.app_logger._logger.info.assert_called_with('Things')
+        self.log_cfg.get_logger.assert_called_with('AppLogger')


### PR DESCRIPTION
The PR adds an Assembly object responsible to resolve the location and optionally download and assembly fasta and report. It retrieves the report via FTP and can get the fasta either via FTP of via download of individual contigs.
Usage for it is: 
```python
assembly = NCBIAssembly('GCA_000008865.1', 'Escherichia coli O157:H7 str. Sakai', download_destination)
assembly.download_or_construct()
```

To only download the report
```python
assembly = NCBIAssembly('GCA_000008865.1', 'Escherichia coli O157:H7 str. Sakai', download_destination)
assembly.download_assembly_report()
```

It also adds a central logging mechanisms which will allow all python program to log in a similar way.
You can use it by:

```python
from ebi_eva_common_pyutils.logger import logging_config as log_cfg 
log_cfg.add_stderr_handler()
logger = log_cfg.get_logger(__name__)
logger.info('Information')
```
Or 
```python
from ebi_eva_common_pyutils.logger import logging_config as log_cfg 

class Foo(log_cfg.AppLogger):

    def bar(self):
        self.info('Information'a)

def main():
    log_cfg.add_stderr_handler()
```
 
