### PR TITLE
EVA-2448 - Refactor database credential access

### DIFF
--- a/ebi_eva_common_pyutils/config_utils.py
+++ b/ebi_eva_common_pyutils/config_utils.py
@@ -37,7 +37,12 @@ class EVAPrivateSettingsXMLConfig:
         return result
 
 
-def get_metadata_creds_for_profile(profile_name, settings_xml_file):
+def get_metadata_creds_for_profile(profile_name: str, settings_xml_file: str):
+    """
+    Gets host, username, and password for metadata postgres database.
+    Useful for filling properties files, for connection purposes you can use
+    `metadata_utils.get_metadata_connection_handle`.
+    """
     properties = get_properties_from_xml_file(profile_name, settings_xml_file)
     pg_url = properties['eva.evapro.jdbc.url']
     pg_user = properties['eva.evapro.user']
@@ -45,7 +50,12 @@ def get_metadata_creds_for_profile(profile_name, settings_xml_file):
     return pg_url, pg_user, pg_pass
 
 
-def get_mongo_creds_for_profile(profile_name, settings_xml_file):
+def get_primary_mongo_creds_for_profile(profile_name: str, settings_xml_file: str):
+    """
+    Gets primary host, username, and password for mongo database.
+    Useful for filling properties files, for connection purposes it is preferable to use
+    `mongo_utils.get_mongo_connection_handle` as that will handle multiple hosts appropriately.
+    """
     properties = get_properties_from_xml_file(profile_name, settings_xml_file)
     # Use the primary mongo host from configuration:
     # https://github.com/EBIvariation/configuration/blob/master/eva-maven-settings.xml#L111
@@ -59,7 +69,11 @@ def get_mongo_creds_for_profile(profile_name, settings_xml_file):
     return mongo_host, mongo_user, mongo_pass
 
 
-def get_accession_pg_creds_for_profile(profile_name, settings_xml_file):
+def get_accession_pg_creds_for_profile(profile_name: str, settings_xml_file: str):
+    """
+    Gets host, username, and password for accessioning job tracker database.
+    Useful for filling properties files.
+    """
     properties = get_properties_from_xml_file(profile_name, settings_xml_file)
     pg_url = properties['eva.accession.jdbc.url']
     pg_user = properties['eva.accession.user']

--- a/ebi_eva_common_pyutils/config_utils.py
+++ b/ebi_eva_common_pyutils/config_utils.py
@@ -17,6 +17,8 @@ from lxml import etree as et
 import json
 import yaml
 import urllib.request
+
+from pymongo.uri_parser import split_hosts
 from retry import retry
 
 
@@ -33,6 +35,33 @@ class EVAPrivateSettingsXMLConfig:
         if not result:
             raise ValueError("Invalid XPath location: " + location)
         return result
+
+
+def get_metadata_creds_for_profile(profile_name, settings_xml_file):
+    properties = get_properties_from_xml_file(profile_name, settings_xml_file)
+    pg_url = properties['eva.evapro.jdbc.url']
+    pg_user = properties['eva.evapro.user']
+    pg_pass = properties['eva.evapro.password']
+    return pg_url, pg_user, pg_pass
+
+
+def get_mongo_creds_for_profile(profile_name, settings_xml_file):
+    properties = get_properties_from_xml_file(profile_name, settings_xml_file)
+    # Use the primary mongo host from configuration:
+    # https://github.com/EBIvariation/configuration/blob/master/eva-maven-settings.xml#L111
+    # TODO: revisit once accessioning/variant pipelines can support multiple hosts
+    mongo_host = split_hosts(properties['eva.mongo.host'])[1][0]
+    mongo_user = properties['eva.mongo.user']
+    mongo_pass = properties['eva.mongo.passwd']
+    return mongo_host, mongo_user, mongo_pass
+
+
+def get_accession_pg_creds_for_profile(profile_name, settings_xml_file):
+    properties = get_properties_from_xml_file(profile_name, settings_xml_file)
+    pg_url = properties['eva.accession.jdbc.url']
+    pg_user = properties['eva.accession.user']
+    pg_pass = properties['eva.accession.password']
+    return pg_url, pg_user, pg_pass
 
 
 def get_pg_uri_for_accession_profile(profile_name: str, settings_xml_file: str):

--- a/ebi_eva_common_pyutils/metadata_utils.py
+++ b/ebi_eva_common_pyutils/metadata_utils.py
@@ -11,9 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from urllib.parse import urlsplit
 
 import psycopg2
+
+from ebi_eva_common_pyutils.config_utils import get_metadata_creds_for_profile
 from ebi_eva_common_pyutils.pg_utils import get_result_cursor, get_all_results_for_query
+
+
+def get_metadata_connection_handle(profile, settings_xml_file):
+    pg_url, pg_user, pg_pass = get_metadata_creds_for_profile(profile, settings_xml_file)
+    return psycopg2.connect(urlsplit(pg_url).path, user=pg_user, password=pg_pass)
 
 
 def get_db_conn_for_species(species_db_info):

--- a/ebi_eva_common_pyutils/mongo_utils.py
+++ b/ebi_eva_common_pyutils/mongo_utils.py
@@ -16,6 +16,7 @@ import pymongo
 from urllib.parse import quote_plus
 from ebi_eva_common_pyutils.command_utils import run_command_with_output
 from ebi_eva_common_pyutils.common_utils import merge_two_dicts
+from ebi_eva_common_pyutils.config_utils import get_mongo_uri_for_eva_profile, get_primary_mongo_creds_for_profile
 
 
 class MongoConfig:
@@ -29,10 +30,15 @@ class MongoConfig:
             self.parameters["host"] = "localhost"
 
 
-def get_mongo_connection_handle(username: str, password: str, host: str,
-                                port: int = 27017, authentication_database: str = "admin") -> pymongo.MongoClient:
+def get_mongo_connection_handle(profile: str, settings_xml_file: str) -> pymongo.MongoClient:
+    mongo_connection_uri = get_mongo_uri_for_eva_profile(profile, settings_xml_file)
+    return pymongo.MongoClient(mongo_connection_uri)
+
+
+def get_primary_mongo_connection_handle(profile: str, settings_xml_file: str) -> pymongo.MongoClient:
+    host, username, password = get_primary_mongo_creds_for_profile(profile, settings_xml_file)
     mongo_connection_uri = "mongodb://{0}:{1}@{2}:{3}/{4}".format(username, quote_plus(password), host,
-                                                                  port, authentication_database)
+                                                                  27017, "admin")
     return pymongo.MongoClient(mongo_connection_uri)
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages
 setup(
     name='ebi_eva_common_pyutils',
     packages=find_packages(),
-    version='0.3.13',
+    version='0.3.14',
     license='Apache',
     description='EBI EVA - Common Python Utilities',
     url='https://github.com/EBIVariation/eva-common-pyutils',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url='https://github.com/EBIVariation/eva-common-pyutils',
     keywords=['EBI', 'EVA', 'PYTHON', 'UTILITIES'],
     install_requires=['psycopg2-binary', 'requests', 'pymongo', 'lxml', 'pyyaml', 'cached-property', 'retry',
-                      'networkx'],
+                      'networkx<=2.5'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/tests/resources/test_config_file.xml
+++ b/tests/resources/test_config_file.xml
@@ -3,7 +3,7 @@
         <profile>
             <id>test</id>
             <properties>
-                <eva.mongo.host>mongo.example.com:27017</eva.mongo.host>
+                <eva.mongo.host>mongo.example.com:27017,mongo.example-primary.com:27017</eva.mongo.host>
                 <eva.mongo.user>testuser</eva.mongo.user>
                 <eva.mongo.passwd>testpassword</eva.mongo.passwd>
                 <eva.mongo.passwd.url-encoded>testpassword</eva.mongo.passwd.url-encoded>

--- a/tests/resources/test_config_file.xml
+++ b/tests/resources/test_config_file.xml
@@ -12,6 +12,15 @@
                 <eva.evapro.jdbc.url>jdbc:postgresql://pgsql.example.com:5432/testdatabase</eva.evapro.jdbc.url>
             </properties>
         </profile>
+        <profile>
+            <id>local</id>
+            <properties>
+                <eva.mongo.host>localhost:27017</eva.mongo.host>
+                <eva.mongo.user></eva.mongo.user>
+                <eva.mongo.passwd></eva.mongo.passwd>
+                <eva.mongo.auth.db></eva.mongo.auth.db>
+            </properties>
+        </profile>
     </profiles>
     <servers>
         <server>

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -15,7 +15,7 @@ import os
 from lxml.etree import XPathEvalError
 
 from ebi_eva_common_pyutils.config_utils import EVAPrivateSettingsXMLConfig, get_pg_metadata_uri_for_eva_profile, \
-    get_mongo_uri_for_eva_profile, get_mongo_creds_for_profile
+    get_mongo_uri_for_eva_profile, get_primary_mongo_creds_for_profile
 from tests.test_common import TestCommon
 
 
@@ -70,12 +70,12 @@ class TestDatabaseConfig(TestCommon):
             'mongodb://localhost:27017'
         )
 
-    def test_get_mongo_creds_for_profile(self):
+    def test_get_primary_mongo_creds_for_profile(self):
         self.assertEqual(
-            get_mongo_creds_for_profile('test', self.config_file),
+            get_primary_mongo_creds_for_profile('test', self.config_file),
             ('mongo.example-primary.com', 'testuser', 'testpassword')
         )
         self.assertEqual(
-            get_mongo_creds_for_profile('local', self.config_file),
+            get_primary_mongo_creds_for_profile('local', self.config_file),
             ('localhost', None, None)
         )

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -64,9 +64,18 @@ class TestDatabaseConfig(TestCommon):
             ValueError,
             get_mongo_uri_for_eva_profile, 'test1', self.config_file
         )
+        # test for local mongo with no authentication
+        self.assertEqual(
+            get_mongo_uri_for_eva_profile('local', self.config_file),
+            'mongodb://localhost:27017'
+        )
 
     def test_get_mongo_creds_for_profile(self):
         self.assertEqual(
             get_mongo_creds_for_profile('test', self.config_file),
             ('mongo.example-primary.com', 'testuser', 'testpassword')
+        )
+        self.assertEqual(
+            get_mongo_creds_for_profile('local', self.config_file),
+            ('localhost', None, None)
         )

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -15,7 +15,7 @@ import os
 from lxml.etree import XPathEvalError
 
 from ebi_eva_common_pyutils.config_utils import EVAPrivateSettingsXMLConfig, get_pg_metadata_uri_for_eva_profile, \
-    get_mongo_uri_for_eva_profile
+    get_mongo_uri_for_eva_profile, get_mongo_creds_for_profile
 from tests.test_common import TestCommon
 
 
@@ -30,7 +30,7 @@ class TestEVAPrivateSettingsXMLConfig(TestCommon):
             self.private_settings.get_value_with_xpath(
                 '//settings/profiles/profile/id[text()="test"]/../properties/eva.mongo.host/text()'
             ),
-            ['mongo.example.com:27017']
+            ['mongo.example.com:27017,mongo.example-primary.com:27017']
         )
         self.assertRaises(
             ValueError,
@@ -58,9 +58,15 @@ class TestDatabaseConfig(TestCommon):
     def test_get_mongo_uri_for_eva_profile(self):
         self.assertEqual(
             get_mongo_uri_for_eva_profile('test', self.config_file),
-            'mongodb://testuser:testpassword@mongo.example.com:27017/admin'
+            'mongodb://testuser:testpassword@mongo.example.com:27017,mongo.example-primary.com:27017/admin'
         )
         self.assertRaises(
             ValueError,
             get_mongo_uri_for_eva_profile, 'test1', self.config_file
+        )
+
+    def test_get_mongo_creds_for_profile(self):
+        self.assertEqual(
+            get_mongo_creds_for_profile('test', self.config_file),
+            ('mongo.example-primary.com', 'testuser', 'testpassword')
         )


### PR DESCRIPTION
Adds the following:
* Methods for getting credentials rather than connection strings - mostly useful for filling properties files (e.g. submission automation, remapping automation)
* Some convenience methods for getting connection handles directly
* Support for connecting to mongo without authentication (e.g. for local testing)

If there's some functionality you'd like that I missed, speak now or ~forever hold your peace~ we'll just add it later.