### PR TITLE
EVA-3050 - Library methods to support assembly ingestion processing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         mongodb-version: [4.0.18]
         python-version: [3.8, 3.9]
-        java-version: [1.8]
+        java-version: [1.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,132 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Pycharm project
+.idea/

--- a/ebi_eva_common_pyutils/common_utils.py
+++ b/ebi_eva_common_pyutils/common_utils.py
@@ -17,3 +17,14 @@ def merge_two_dicts(x, y):
     z = x.copy()  # start with x's keys and values
     z.update(y)  # modifies z with y's keys and values & returns None
     return z
+
+
+def pretty_print(header, table):
+    cell_widths = [len(h) for h in header]
+    for row in table:
+        for i, cell in enumerate(row):
+            cell_widths[i] = max(cell_widths[i], len(str(cell)))
+    format_string = ' | '.join('{%s:>%s}' % (i, w) for i, w in enumerate(cell_widths))
+    print('| ' + format_string.format(*header) + ' |')
+    for row in table:
+        print('| ' + format_string.format(*row) + ' |')

--- a/ebi_eva_common_pyutils/contig_alias/contig_alias.py
+++ b/ebi_eva_common_pyutils/contig_alias/contig_alias.py
@@ -48,7 +48,7 @@ class ContigAliasClient(AppLogger):
         if response.status_code == 200:
             self.info(f'Assembly accession {assembly} successfully added to Contig-Alias DB')
         elif response.status_code == 409:
-            self.warning(f'Assembly accession {assembly} already exist in Contig-Alias DB. Response: {response.text}')
+            self.warning(f'Assembly accession {assembly} already exists in Contig-Alias DB. Response: {response.text}')
         elif response.status_code == 500:
             self.error(f'Could not save Assembly accession {assembly} to Contig-Alias DB. Error: {response.text}')
             raise InternalServerError

--- a/ebi_eva_common_pyutils/contig_alias/contig_alias.py
+++ b/ebi_eva_common_pyutils/contig_alias/contig_alias.py
@@ -54,6 +54,7 @@ class ContigAliasClient(AppLogger):
             raise InternalServerError
         else:
             self.error(f'Could not save Assembly accession {assembly} to Contig-Alias DB. Error: {response.text}')
+            response.raise_for_status()
 
     @retry(InternalServerError, tries=3, delay=2, backoff=1.5, jitter=(1, 3))
     def delete_assembly(self, assembly):

--- a/ebi_eva_common_pyutils/contig_alias/contig_alias.py
+++ b/ebi_eva_common_pyutils/contig_alias/contig_alias.py
@@ -1,0 +1,70 @@
+# Copyright 2022 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+from ebi_eva_common_pyutils.logger import AppLogger
+import requests
+from retry import retry
+
+
+class InternalServerError(Exception):
+    pass
+
+
+# TODO add the get methods
+class ContigAliasClient(AppLogger):
+    """
+    Python client for interfacing with the contig alias service.
+    Authentication is required if using admin endpoints.
+    """
+
+    def __init__(self, base_url, username=None, password=None):
+        self.base_url = base_url
+        # Only required for admin endpoints
+        self.username = username
+        self.password = password
+
+    def check_auth(self):
+        if self.username is None or self.password is None:
+            raise ValueError('Need admin username and password for this method')
+
+    @retry(InternalServerError, tries=3, delay=2, backoff=1.5, jitter=(1, 3))
+    def insert_assembly(self, assembly):
+        self.check_auth()
+        full_url = os.path.join(self.base_url, f'v1/admin/assemblies/{assembly}')
+
+        response = requests.put(full_url, auth=(self.username, self.password))
+        if response.status_code == 200:
+            self.info(f'Assembly accession {assembly} successfully added to Contig-Alias DB')
+        elif response.status_code == 409:
+            self.warning(f'Assembly accession {assembly} already exist in Contig-Alias DB. Response: {response.text}')
+        elif response.status_code == 500:
+            self.error(f'Could not save Assembly accession {assembly} to Contig-Alias DB. Error: {response.text}')
+            raise InternalServerError
+        else:
+            self.error(f'Could not save Assembly accession {assembly} to Contig-Alias DB. Error: {response.text}')
+
+    @retry(InternalServerError, tries=3, delay=2, backoff=1.5, jitter=(1, 3))
+    def delete_assembly(self, assembly):
+        self.check_auth()
+        full_url = os.path.join(self.base_url, f'v1/admin/assemblies/{assembly}')
+
+        response = requests.delete(full_url, auth=(self.username, self.password))
+        if response.status_code == 200:
+            self.info(f'Assembly accession {assembly} successfully deleted from Contig-Alias DB')
+        elif response.status_code == 500:
+            self.error(f'Assembly accession {assembly} could not be deleted. Response: {response.text}')
+            raise InternalServerError
+        else:
+            self.error(f'Assembly accession {assembly} could not be deleted. Response: {response.text}')

--- a/ebi_eva_common_pyutils/mongo_utils.py
+++ b/ebi_eva_common_pyutils/mongo_utils.py
@@ -14,6 +14,9 @@
 
 import pymongo
 from urllib.parse import quote_plus
+
+from pymongo import ReadPreference
+
 from ebi_eva_common_pyutils.command_utils import run_command_with_output
 from ebi_eva_common_pyutils.common_utils import merge_two_dicts
 from ebi_eva_common_pyutils.config_utils import get_mongo_uri_for_eva_profile, get_primary_mongo_creds_for_profile
@@ -30,16 +33,28 @@ class MongoConfig:
             self.parameters["host"] = "localhost"
 
 
-def get_mongo_connection_handle(profile: str, settings_xml_file: str) -> pymongo.MongoClient:
+def get_mongo_connection_handle(profile: str, settings_xml_file: str,
+                                read_concern: str = "majority",
+                                read_preference: ReadPreference = ReadPreference.PRIMARY,
+                                write_concern: str = "majority") -> pymongo.MongoClient:
     mongo_connection_uri = get_mongo_uri_for_eva_profile(profile, settings_xml_file)
-    return pymongo.MongoClient(mongo_connection_uri)
+    return pymongo.MongoClient(mongo_connection_uri,
+                               readConcernLevel=read_concern,
+                               read_preference=read_preference,
+                               w=write_concern)
 
 
-def get_primary_mongo_connection_handle(profile: str, settings_xml_file: str) -> pymongo.MongoClient:
+def get_primary_mongo_connection_handle(profile: str, settings_xml_file: str,
+                                        read_concern: str = "majority",
+                                        read_preference: ReadPreference = ReadPreference.PRIMARY,
+                                        write_concern: str = "majority") -> pymongo.MongoClient:
     host, username, password = get_primary_mongo_creds_for_profile(profile, settings_xml_file)
     mongo_connection_uri = "mongodb://{0}:{1}@{2}:{3}/{4}".format(username, quote_plus(password), host,
                                                                   27017, "admin")
-    return pymongo.MongoClient(mongo_connection_uri)
+    return pymongo.MongoClient(mongo_connection_uri,
+                               readConcernLevel=read_concern,
+                               read_preference=read_preference,
+                               w=write_concern)
 
 
 def copy_db_with_config(mongo_source_config: MongoConfig, mongo_destination_config: MongoConfig, mongodump_args: dict,

--- a/ebi_eva_common_pyutils/ncbi_utils.py
+++ b/ebi_eva_common_pyutils/ncbi_utils.py
@@ -82,7 +82,7 @@ def get_ncbi_assembly_name_from_term(term):
     return assembly_names.pop() if assembly_names else None
 
 
-def retrieve_species_names_from_tax_id_ncbi(taxid):
+def retrieve_species_scientific_name_from_tax_id_ncbi(taxid):
     payload = {'db': 'Taxonomy', 'id': taxid}
     r = requests.get(efetch_url, params=payload)
     match = re.search('<Rank>(.+?)</Rank>', r.text, re.MULTILINE)

--- a/ebi_eva_common_pyutils/spring_properties.py
+++ b/ebi_eva_common_pyutils/spring_properties.py
@@ -1,0 +1,115 @@
+# Copyright 2022 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ebi_eva_common_pyutils.config_utils import get_primary_mongo_creds_for_profile, get_accession_pg_creds_for_profile,\
+    get_count_service_creds_for_profile
+
+
+class SpringPropertiesGenerator:
+    """
+    Class to generate Spring properties for various Spring Batch pipelines.
+    These methods can be used to generate complete properties files entirely in Python; alternatively, certain
+    properties can be left unfilled and supplied as command-line arguments (e.g. by a NextFlow process).
+    """
+
+    def __init__(self, maven_profile, private_settings_file):
+        self.maven_profile = maven_profile
+        self.private_settings_file = private_settings_file
+
+    def _common_properties(self):
+        """Properties common to all Spring pipelines"""
+        mongo_host, mongo_user, mongo_pass = get_primary_mongo_creds_for_profile(
+            self.maven_profile, self.private_settings_file)
+        pg_url, pg_user, pg_pass = get_accession_pg_creds_for_profile(self.maven_profile, self.private_settings_file)
+        return f'''spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url={pg_url}
+spring.datasource.username={pg_user}
+spring.datasource.password={pg_pass}
+spring.datasource.tomcat.max-active=3
+
+spring.jpa.generate-ddl=true
+
+spring.data.mongodb.host={mongo_host}
+spring.data.mongodb.port=27017
+spring.data.mongodb.database=eva_accession_sharded
+spring.data.mongodb.username={mongo_user}
+spring.data.mongodb.password={mongo_pass}
+
+spring.data.mongodb.authentication-database=admin
+mongodb.read-preference=secondaryPreferred
+spring.main.web-application-type=none
+spring.main.allow-bean-definition-overriding=true
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+logging.level.uk.ac.ebi.eva.accession.remapping=INFO
+parameters.chunkSize=1000
+'''
+
+    def _accessioning_properties(self, instance):
+        """Properties common to accessioning and clustering pipelines."""
+        counts_url, counts_username, counts_password = get_count_service_creds_for_profile(
+            self.maven_profile, self.private_settings_file)
+        return f'''
+accessioning.instanceId=instance-{instance}
+accessioning.submitted.categoryId=ss
+accessioning.clustered.categoryId=rs
+
+accessioning.monotonic.ss.blockSize=100000
+accessioning.monotonic.ss.blockStartValue=5000000000
+accessioning.monotonic.ss.nextBlockInterval=1000000000
+accessioning.monotonic.rs.blockSize=100000
+accessioning.monotonic.rs.blockStartValue=3000000000
+accessioning.monotonic.rs.nextBlockInterval=1000000000
+
+eva.count-stats.url={counts_url}
+eva.count-stats.username={counts_username}
+eva.count-stats.password={counts_password}
+'''
+
+    def get_remapping_extraction_properties(self, *, taxonomy='', source_assembly='', fasta='', assembly_report='',
+                                            projects='', output_folder='.'):
+        """Properties for remapping extraction pipeline."""
+        return self._common_properties() + f'''
+spring.batch.job.names=EXPORT_SUBMITTED_VARIANTS_JOB
+parameters.taxonomy={taxonomy}
+parameters.assemblyAccession={source_assembly}
+parameters.fasta={fasta}
+parameters.assemblyReportUrl=file:{assembly_report}
+parameters.projects={projects}
+parameters.outputFolder={output_folder}
+'''
+
+    def get_remapping_ingestion_properties(self, *, source_assembly='', target_assembly='', vcf='', load_to='',
+                                           remapping_version=1.0):
+        """Properties for remapping ingestion pipeline."""
+        return self._common_properties() + f'''
+spring.batch.job.names=INGEST_REMAPPED_VARIANTS_FROM_VCF_JOB
+parameters.vcf={vcf}
+parameters.assemblyAccession={target_assembly}
+parameters.remappedFrom={source_assembly}
+parameters.loadTo={load_to}
+parameters.remappingVersion={remapping_version}
+'''
+
+    def get_clustering_properties(self, *, instance,
+                                  job_name='', target_assembly='', rs_report_path='', projects='',
+                                  project_accession='', vcf='', source_assembly=''):
+        """Properties common to all clustering pipelines, though not all are always used."""
+        return self._common_properties() + self._accessioning_properties(instance) + f'''
+spring.batch.job.names={job_name}
+parameters.projects={projects}
+parameters.projectAccession={project_accession}
+parameters.vcf={vcf}
+parameters.assemblyAccession={target_assembly}
+parameters.remappedFrom={source_assembly}
+parameters.rsReportPath={rs_report_path}
+'''

--- a/ebi_eva_common_pyutils/taxonomy/taxonomy.py
+++ b/ebi_eva_common_pyutils/taxonomy/taxonomy.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import re
+
+from ebi_eva_common_pyutils.ncbi_utils import retrieve_species_names_from_tax_id_ncbi
 from ebi_eva_common_pyutils.network_utils import json_request
 
 
@@ -37,3 +39,14 @@ def normalise_taxon_scientific_name(taxon_name):
 def get_normalized_scientific_name_from_ensembl(taxonomy_id: int) -> str:
     """Get the scientific name for that taxon"""
     return normalise_taxon_scientific_name(get_scientific_name_from_ensembl(taxonomy_id))
+
+
+def get_scientific_name_from_taxonomy(taxonomy_id: int) -> str:
+    """
+    Search for a species scientific name based on the taxonomy id.
+    Will first attempt to retrieve from Ensembl and then NCBI, if not found returns None.
+    """
+    species_name = get_scientific_name_from_ensembl(taxonomy_id)
+    if not species_name:
+        species_name = retrieve_species_names_from_tax_id_ncbi(taxonomy_id)
+    return species_name

--- a/ebi_eva_common_pyutils/taxonomy/taxonomy.py
+++ b/ebi_eva_common_pyutils/taxonomy/taxonomy.py
@@ -14,7 +14,7 @@
 
 import re
 
-from ebi_eva_common_pyutils.ncbi_utils import retrieve_species_names_from_tax_id_ncbi
+from ebi_eva_common_pyutils.ncbi_utils import retrieve_species_scientific_name_from_tax_id_ncbi
 from ebi_eva_common_pyutils.network_utils import json_request
 
 
@@ -48,5 +48,5 @@ def get_scientific_name_from_taxonomy(taxonomy_id: int) -> str:
     """
     species_name = get_scientific_name_from_ensembl(taxonomy_id)
     if not species_name:
-        species_name = retrieve_species_names_from_tax_id_ncbi(taxonomy_id)
+        species_name = retrieve_species_scientific_name_from_tax_id_ncbi(taxonomy_id)
     return species_name

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,7 @@
 import os
 from unittest import TestCase
 
-from ebi_eva_common_pyutils.common_utils import merge_two_dicts
+from ebi_eva_common_pyutils.common_utils import merge_two_dicts, pretty_print
 
 
 class TestCommon(TestCase):
@@ -16,3 +16,7 @@ class TestCommonUtils(TestCase):
         d2 = {'d': 4, 'a': 5, 'e': 6}
         assert merge_two_dicts(d1, d2) == {'a': 5, 'b': 2, 'c': 3, 'd': 4, 'e': 6}
         assert merge_two_dicts(d2, d1) == {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 6}
+
+    def test_pretty_print(self):
+        pretty_print(['Header 1', 'Long Header 2'],
+                     [['row1 cell 1', 'row1 cell 2'], ['row2 cell 1', 'Super long row2 cell 2']])

--- a/tests/test_mongodb.py
+++ b/tests/test_mongodb.py
@@ -2,8 +2,11 @@ import os
 import tempfile
 
 import pymongo
+from pymongo import WriteConcern, ReadPreference
+from pymongo.read_concern import ReadConcern
 
 from ebi_eva_common_pyutils.command_utils import run_command_with_output
+from ebi_eva_common_pyutils.mongo_utils import get_mongo_connection_handle
 from ebi_eva_common_pyutils.mongodb import MongoDatabase
 from tests.test_common import TestCommon
 
@@ -12,6 +15,7 @@ class TestMongoDatabase(TestCommon):
     dump_db_name = "test_mongo_db"
     uri = "mongodb://localhost:27017/admin"
     local_mongo_handle = pymongo.MongoClient()
+    config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources/test_config_file.xml')
 
     # Tests expect a local sharded Mongo instance
     def setUp(self) -> None:
@@ -162,3 +166,9 @@ class TestMongoDatabase(TestCommon):
 
             # delete the newly created temp collection
             self.test_mongo_db.mongo_handle[self.dump_db_name][new_collection_name].drop()
+
+    def test_get_mongo_connection_handle_sets_defaults(self):
+        conn = get_mongo_connection_handle('local', self.config_file)
+        self.assertEqual(conn.write_concern, WriteConcern('majority'))
+        self.assertEqual(conn.read_concern, ReadConcern('majority'))
+        self.assertEqual(conn.read_preference, ReadPreference.PRIMARY)


### PR DESCRIPTION
* Contig alias client - I think this will be generally useful but for now it only contains the admin methods used in eva-assembly-ingestion, copied directly from the [existing load script in tasks](https://github.com/EBIvariation/eva-tasks/blob/master/tasks/eva_2877/load_to_contig_alias_db.py)
* Spring properties generator - intended to be "source of truth" for our properties files as used in Python automation.  The idea of all the default params is so that different workflows can opt to leave them out (filling them in Nextflow for example), but the method in this library is still complete regarding what is needed for the Java code.
* Some utilities regarding taxonomy species name that I transferred from [gather release species](https://github.com/EBIvariation/eva-tools/blob/master/variant-remapping-automation/gather_release_species.py)
* Default read/write concern on Mongo connections - this is totally unrelated to the ticket so I can remove if you prefer, but I think the java version is needed for the nextflow tests to run in github actions...