### PR TITLE
Update lxml version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests==2.*
+lxml==5.*
+pyyaml==6.*
+cached-property==1.5.*
+retry>0.9,==0.*
+openpyxl==3.*

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 import os
 from distutils.core import setup
+from os.path import abspath, dirname, join
 
 from setuptools import find_packages
+base_dir = abspath(dirname(__file__))
+requirements_txt = join(base_dir, 'requirements.txt')
+requirements = [l.strip() for l in open(requirements_txt) if l and not l.startswith('#')]
 
 setup(
     name='ebi_eva_common_pyutils',
@@ -12,8 +16,7 @@ setup(
     description='EBI EVA - Common Python Utilities',
     url='https://github.com/EBIVariation/eva-common-pyutils',
     keywords=['EBI', 'EVA', 'PYTHON', 'UTILITIES'],
-    install_requires=['requests==2.*', 'lxml>4.9,==4.*', 'pyyaml==6.*', 'cached-property==1.5.*', 'retry>0.9,==0.*',
-                      'openpyxl==3.*'],
+    install_requires=requirements,
     extras_require={'eva-internal': ['psycopg2-binary', 'pymongo', 'networkx<=2.5']},
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/common/test_contig_alias.py
+++ b/tests/common/test_contig_alias.py
@@ -16,7 +16,7 @@ class TestContigAliasClient(TestCase):
         iterator = self.client.assembly_contig_iter(self.assembly_accession)
         assert isinstance(iterator, Iterable)
         # print(list(iterator))
-        assert [e.get('genbankSequenceName') for e in iterator] == ['I', 'II', 'III', 'MT']
+        assert [e.get('genbankSequenceName') for e in iterator] == ['MT', 'III', 'II', 'I']
 
     def test_assembly(self):
         assembly = self.client.assembly(self.assembly_accession)


### PR DESCRIPTION
Convert to using `requirement.txt`
Update lxml from 4.* to 5.* : I don't expect this to have any effect but it seems that the lxml 4.* on conda does not allow python 3.13 see (https://github.com/EBIvariation/eva-sub-cli/issues/89#issuecomment-2938894490)
We will have to update the requirement on bioconda [recipies](https://github.com/bioconda/bioconda-recipes/blob/00887b817f7751c0843d58b6d7d296449ff1807e/recipes/ebi-eva-common-pyutils/meta.yaml#L27) as well. 
