### PR TITLE
Prevent multiple config from sharing the same content

### DIFF
--- a/ebi_eva_common_pyutils/config.py
+++ b/ebi_eva_common_pyutils/config.py
@@ -11,10 +11,9 @@ class Configuration:
     Configuration class that allow to load a yaml file either at construction or later in the execution.
     It can be used like a dict but should be used as readonly.
     """
-    config_file = None
-    content = {}
-
     def __init__(self, *search_path):
+        self.config_file = None
+        self.content = {}
         if search_path:
             self.load_config_file(*search_path)
 


### PR DESCRIPTION
The use of the class level dict at initialisation of the class means that all config object would share the same content. 
In most case the original dict gets overwritten when the actual file is loaded.
In some rare (test related) case when multiple config are created and no files are loaded then the original content dict is shared between them.