### PR TITLE
EVA-4113 use dev1 instead of dev0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     name='ebi_eva_common_pyutils',
     scripts=[os.path.join(os.path.dirname(__file__), 'ebi_eva_internal_pyutils', 'archive_directory.py')],
     packages=find_packages(),
-    version='1.0.0.dev0',
+    version='1.0.0.dev1',
     license='Apache',
     description='EBI EVA - Common Python Utilities',
     url='https://github.com/EBIVariation/eva-common-pyutils',


### PR DESCRIPTION
I had earlier used **1.0.0.dev0** and then deleted it and replaced it with **0.9.9.dev0** because it was causing issues in eva-submission/eva-sub-cli. But because **1.0.0.dev0** has already been used, py-pi is not allowing me to use the same version again (even though it has been deleted), so I changed and deployed **1.0.0.dev1**