### PR TITLE
Update lxml version in requirements.txt

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ test:
   stage: test
   image: python:3.11-slim-bullseye
   before_script:
-    - apt-get update && apt-get install curl default-jre -y
+    - apt-get update && apt-get install curl openjdk-21 -y
     - mkdir /tmp/nextflow && cd /tmp/nextflow && (curl -s https://get.nextflow.io | bash) && chmod 755 nextflow $$ export PATH=/tmp/:$PATH && cd -
     - nextflow -version
     - python -m pip install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.*
-lxml==5.*
+lxml==6.*
 pyyaml==6.*
 cached-property==1.5.*
 retry>0.9,==0.*


### PR DESCRIPTION
I'm having issues with lxml not building in Gitlab because the old versio has no Wheel available. version 6.* only loose support for python 3.8 so we should be fine with the [changes](https://github.com/lxml/lxml/releases/tag/lxml-6.0.0) 
Also attempted to fix the gitlab build